### PR TITLE
Users companies relationship

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -17,6 +17,9 @@ Metrics/BlockLength:
     - "spec/**/*"
     - "db/schema.rb"
 
+Metrics/MethodLength:
+  Max: 20
+
 Rails/FilePath:
   Enabled: false
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -18,7 +18,8 @@ Metrics/BlockLength:
     - "db/schema.rb"
 
 Metrics/MethodLength:
-  Max: 20
+  Exclude:
+    - "db/migrate/*"
 
 Rails/FilePath:
   Enabled: false

--- a/app/assets/stylesheets/members.scss
+++ b/app/assets/stylesheets/members.scss
@@ -1,0 +1,3 @@
+// Place all the styles related to the Members controller here.
+// They will automatically be included in application.css.
+// You can use Sass (SCSS) here: https://sass-lang.com/

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -3,7 +3,7 @@ class MembersController < ApplicationController
 
   def index
     @company_name = @company.name
-    @members_relation = @company.users_companies_relationships
+    @members = @company.users
   end
 
   private

--- a/app/controllers/members_controller.rb
+++ b/app/controllers/members_controller.rb
@@ -1,0 +1,14 @@
+class MembersController < ApplicationController
+  before_action :find_company_by_id, only: :index
+
+  def index
+    @company_name = @company.name
+    @members_relation = @company.users_companies_relationships
+  end
+
+  private
+
+  def find_company_by_id
+    @company = Company.find(params[:company_id])
+  end
+end

--- a/app/controllers/users_controller.rb
+++ b/app/controllers/users_controller.rb
@@ -43,7 +43,7 @@ class UsersController < ApplicationController
   private
 
   def user_params
-    params.require(:user).permit(:first_name, :last_name, :email, :is_admin)
+    params.require(:user).permit(:first_name, :last_name, :email)
   end
 
   def full_name; end

--- a/app/helpers/members_helper.rb
+++ b/app/helpers/members_helper.rb
@@ -1,0 +1,2 @@
+module MembersHelper
+end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,2 +1,5 @@
 module UsersHelper
+  def show_company_link(user)
+    link_to user.company.name, user.company if user.company.present?
+  end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,5 +1,20 @@
 module UsersHelper
-  def show_company_link(user)
-    link_to user.company.name, user.company if user.company.present?
+  def user_company_content(user)
+    company_role_and_link(user) if user.company.present?
+  end
+
+  private
+
+  def link_to_user_company(user)
+    link_to(user.company.name, user.company)
+  end
+
+  def company_role_at(user)
+    content_tag(:span,
+                "#{user.users_companies_relationship.role.capitalize} at")
+  end
+
+  def company_role_and_link(user)
+    company_role_at(user) + link_to_user_company(user)
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -4,7 +4,7 @@ module UsersHelper
   end
 
   def user_role_string(user)
-    user.users_companies_relationship.role.capitalize.gsub('_', ' ')
+    user.role.capitalize.gsub('_', ' ')
   end
 
   def user_company_content(user)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -4,7 +4,7 @@ module UsersHelper
   end
 
   def user_role_string(user)
-    user.role.capitalize.gsub('_', ' ')
+    user.role&.capitalize&.gsub('_', ' ')
   end
 
   def user_company_content(user)

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -1,4 +1,8 @@
 module UsersHelper
+  def full_user_name(user)
+    user.first_name + ' ' + user.last_name
+  end
+
   def user_company_content(user)
     company_role_and_link(user) if user.company.present?
   end
@@ -15,6 +19,8 @@ module UsersHelper
   end
 
   def company_role_and_link(user)
-    company_role_at(user) + link_to_user_company(user)
+    content_tag(:div,
+                company_role_at(user) + link_to_user_company(user),
+                class: 'company-role')
   end
 end

--- a/app/helpers/users_helper.rb
+++ b/app/helpers/users_helper.rb
@@ -3,6 +3,10 @@ module UsersHelper
     user.first_name + ' ' + user.last_name
   end
 
+  def user_role_string(user)
+    user.users_companies_relationship.role.capitalize.gsub('_', ' ')
+  end
+
   def user_company_content(user)
     company_role_and_link(user) if user.company.present?
   end
@@ -14,8 +18,7 @@ module UsersHelper
   end
 
   def company_role_at(user)
-    content_tag(:span,
-                "#{user.users_companies_relationship.role.capitalize} at")
+    content_tag(:span, "#{user_role_string(user)} at")
   end
 
   def company_role_and_link(user)

--- a/app/models/company.rb
+++ b/app/models/company.rb
@@ -1,7 +1,11 @@
 class Company < ApplicationRecord
-  validates :name, presence: { message: 'can not be blank' }
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i.freeze
   VALID_PHONE_REGEX = /\A(\+)?([ 0-9]){10,14}\z/.freeze
+
+  has_many :users_companies_relationships, dependent: :destroy
+  has_many :users, through: :users_companies_relationships
+
+  validates :name, presence: { message: 'can not be blank' }
   validates :email, presence: { message: 'can not be blank' },
                     uniqueness: { case_sensitive: false }
   validates :email, format: { with: VALID_EMAIL_REGEX, message: 'format is not valid' },

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -8,4 +8,8 @@ class User < ApplicationRecord
   validates :last_name, presence: true, length: { minimum: 3, maximum: 50 }
   validates :email, presence: true, length: { minimum: 8, maximum: 255 },
                     format: { with: VALID_EMAIL_REGEX }
+
+  def role
+    users_companies_relationship.role if company.present?
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -1,6 +1,9 @@
 class User < ApplicationRecord
   VALID_EMAIL_REGEX = /\A[\w+\-.]+@[a-z\d\-]+(\.[a-z\d\-]+)*\.[a-z]+\z/i.freeze
 
+  has_one :users_companies_relationship, dependent: :destroy
+  has_one :company, through: :users_companies_relationship
+
   validates :first_name, presence: true, length: { minimum: 3, maximum: 50 }
   validates :last_name, presence: true, length: { minimum: 3, maximum: 50 }
   validates :email, presence: true, length: { minimum: 8, maximum: 255 },

--- a/app/models/users_companies_relationship.rb
+++ b/app/models/users_companies_relationship.rb
@@ -1,0 +1,8 @@
+class UsersCompaniesRelationship < ApplicationRecord
+  enum role: { company_owner: 0, employee: 1, staff_member: 2 }
+
+  belongs_to :user
+  belongs_to :company
+
+  validates :role, :user, :company, presence: true
+end

--- a/app/views/companies/show.html.slim
+++ b/app/views/companies/show.html.slim
@@ -15,6 +15,8 @@
           strong Phone number:
           span
             = @company.phone
+        .mt-2
+          = link_to 'Company members', company_members_path(@company)
     .col class='edit-delete-links justify-content-end'
       div = link_to icon('fas', 'edit', class: 'strong'), [:edit, @company], class: 'edit-link'
       div = link_to icon('fas', 'trash-alt', class: 'strong'), @company, method: :delete, data: { confirm: "You sure?" }, class: 'delete-link'

--- a/app/views/members/index.html.slim
+++ b/app/views/members/index.html.slim
@@ -11,8 +11,8 @@ h3.mb-4 Members:
             th scope="col" Role
             th scope="col"
         tbody
-        - @members_relation.each do |relation|
+        - @members.each do |member|
           tr
-            td.pl-5 = full_user_name(relation.user)
-            td = relation.role.capitalize
-            td = link_to 'Show', relation.user
+            td.pl-5 = full_user_name(member)
+            td = user_role_string(member)
+            td = link_to 'Show', member

--- a/app/views/members/index.html.slim
+++ b/app/views/members/index.html.slim
@@ -1,0 +1,18 @@
+section.company_members
+h2.mb-4 = @company_name
+h3.mb-4 Members:
+.row
+  .col-11
+    .company_members-table
+      table.table.table-striped
+        thead
+          tr
+            th.pl-5 scope="col" User
+            th scope="col" Role
+            th scope="col"
+        tbody
+        - @members_relation.each do |relation|
+          tr
+            td.pl-5 = full_user_name(relation.user)
+            td = relation.role.capitalize
+            td = link_to 'Show', relation.user

--- a/app/views/users/_users.html.slim
+++ b/app/views/users/_users.html.slim
@@ -1,4 +1,4 @@
-= @users.each do |user| 
+- @users.each do |user|
   p.full-name 
     span
       = user.first_name

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -7,6 +7,8 @@
       p 
         span Email: 
         span = @user.email
+      p
+        = user_company_content(@user)
       nav
         ul.nav.navbar
           li.nav-item = link_to 'Edit user profile', edit_user_path, class: "btn btn-warning"

--- a/app/views/users/show.html.slim
+++ b/app/views/users/show.html.slim
@@ -4,11 +4,10 @@
       .full-name
         h1 = @user.first_name 
         h1 = @user.last_name
+      = user_company_content(@user)
       p 
         span Email: 
         span = @user.email
-      p
-        = user_company_content(@user)
       nav
         ul.nav.navbar
           li.nav-item = link_to 'Edit user profile', edit_user_path, class: "btn btn-warning"

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,5 +1,4 @@
 Rails.application.routes.draw do
-  get 'members/index'
   root 'home#index'
 
   resources :companies do

--- a/config/routes.rb
+++ b/config/routes.rb
@@ -1,7 +1,11 @@
 Rails.application.routes.draw do
+  get 'members/index'
   root 'home#index'
 
-  resources :companies
+  resources :companies do
+    resources :members, only: :index
+  end
+
   resources :units
   resources :feedbacks, only: %i[index show create destroy]
   resources :users

--- a/db/migrate/20200416072355_change_is_admin_to_be_boolean_in_users.rb
+++ b/db/migrate/20200416072355_change_is_admin_to_be_boolean_in_users.rb
@@ -1,0 +1,17 @@
+class ChangeIsAdminToBeBooleanInUsers < ActiveRecord::Migration[6.0]
+  def change
+    reversible do |dir|
+      change_table :users, bulk: true do |t|
+        dir.up do
+          t.remove :is_admin
+          t.column :is_admin, :boolean, null: false, default: false
+        end
+
+        dir.down do
+          t.remove :is_admin
+          t.column :is_admin, :integer
+        end
+      end
+    end
+  end
+end

--- a/db/migrate/20200416082345_create_users_companies_relationships.rb
+++ b/db/migrate/20200416082345_create_users_companies_relationships.rb
@@ -1,0 +1,16 @@
+class CreateUsersCompaniesRelationships < ActiveRecord::Migration[6.0]
+  def change
+    create_table :users_companies_relationships do |t|
+      t.references :user, null: false, foreign_key: true
+      t.references :company, null: false, foreign_key: true
+      t.integer :role
+
+      t.timestamps
+    end
+
+    add_index :users_companies_relationships,
+              %i[user_id company_id],
+              unique: true,
+              name: :relationship_index
+  end
+end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_200_416_072_355) do
+ActiveRecord::Schema.define(version: 20_200_416_082_345) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
@@ -47,4 +47,18 @@ ActiveRecord::Schema.define(version: 20_200_416_072_355) do
     t.datetime 'updated_at', precision: 6, null: false
     t.boolean 'is_admin', default: false, null: false
   end
+
+  create_table 'users_companies_relationships', force: :cascade do |t|
+    t.bigint 'user_id', null: false
+    t.bigint 'company_id', null: false
+    t.integer 'role'
+    t.datetime 'created_at', precision: 6, null: false
+    t.datetime 'updated_at', precision: 6, null: false
+    t.index ['company_id'], name: 'index_users_companies_relationships_on_company_id'
+    t.index %w[user_id company_id], name: 'relationship_index', unique: true
+    t.index ['user_id'], name: 'index_users_companies_relationships_on_user_id'
+  end
+
+  add_foreign_key 'users_companies_relationships', 'companies'
+  add_foreign_key 'users_companies_relationships', 'users'
 end

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -10,7 +10,7 @@
 #
 # It's strongly recommended that you check this file into your version control system.
 
-ActiveRecord::Schema.define(version: 20_200_413_070_244) do
+ActiveRecord::Schema.define(version: 20_200_416_072_355) do
   # These are extensions that must be enabled in order to support this database
   enable_extension 'plpgsql'
 
@@ -43,8 +43,8 @@ ActiveRecord::Schema.define(version: 20_200_413_070_244) do
     t.string 'first_name'
     t.string 'last_name'
     t.string 'email'
-    t.integer 'is_admin'
     t.datetime 'created_at', precision: 6, null: false
     t.datetime 'updated_at', precision: 6, null: false
+    t.boolean 'is_admin', default: false, null: false
   end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -16,6 +16,8 @@ end
   FactoryBot.create :user
 end
 
-20.times do
-  FactoryBot.create :users_companies_relationship
+Company.all.each do |company|
+  5.times do
+    FactoryBot.create(:users_companies_relationship, company: company)
+  end
 end

--- a/db/seeds.rb
+++ b/db/seeds.rb
@@ -9,9 +9,13 @@ end
 end
 
 50.times do
-  FactoryBot.create(:feedback)
+  FactoryBot.create :feedback
 end
 
 10.times do
   FactoryBot.create :user
+end
+
+20.times do
+  FactoryBot.create :users_companies_relationship
 end

--- a/spec/controllers/members_controller_spec.rb
+++ b/spec/controllers/members_controller_spec.rb
@@ -1,0 +1,15 @@
+require 'rails_helper'
+
+RSpec.describe MembersController, type: :controller do
+  let(:company) { create(:company) }
+  let(:users_companies_relationship) do
+    create(:users_companies_relationship, company: company)
+  end
+
+  describe 'GET #index' do
+    subject { get :index, params: { company_id: company.id } }
+
+    it { is_expected.to have_http_status(:success) }
+    it { is_expected.to render_template('index') }
+  end
+end

--- a/spec/controllers/users_controller_spec.rb
+++ b/spec/controllers/users_controller_spec.rb
@@ -68,8 +68,7 @@ describe UsersController, type: :controller do
       before do
         put :update, params: { id: user.id,
                                user: valid_params.merge!(first_name: 'Another',
-                                                         last_name: 'User',
-                                                         is_admin: 1) }
+                                                         last_name: 'User') }
       end
       it 'assigns the user' do
         expect(assigns(:user)).to eq(user)
@@ -80,7 +79,6 @@ describe UsersController, type: :controller do
         user.reload
         expect(user.first_name).to eq(valid_params[:first_name])
         expect(user.last_name).to eq(valid_params[:last_name])
-        expect(user.is_admin).to eq(valid_params[:is_admin])
       end
     end
     context 'with invalid params' do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
-    first_name { Faker::Internet.username(specifier: 3..50) }
-    last_name { Faker::Internet.username(specifier: 3..50) }
+    first_name { 'Test' }
+    last_name { 'User' }
     is_admin { false }
     sequence(:email) { |n| "user#{n}@example.com" }
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,7 +1,7 @@
 FactoryBot.define do
   factory :user do
-    first_name { Faker::Name.first_name }
-    last_name { Faker::Name.last_name }
+    first_name { Faker::Internet.username(specifier: 3..50) }
+    last_name { Faker::Internet.username(specifier: 3..50) }
     is_admin { false }
     email { Faker::Internet.safe_email }
   end

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -3,7 +3,7 @@ FactoryBot.define do
     first_name { Faker::Internet.username(specifier: 3..50) }
     last_name { Faker::Internet.username(specifier: 3..50) }
     is_admin { false }
-    email { Faker::Internet.safe_email }
+    sequence(:email) { |n| "user#{n}@example.com" }
   end
 
   factory :admin, parent: :user do

--- a/spec/factories/users.rb
+++ b/spec/factories/users.rb
@@ -1,8 +1,12 @@
 FactoryBot.define do
   factory :user do
-    first_name { 'Test' }
-    last_name { 'User' }
-    is_admin { 1 }
-    sequence(:email) { |n| "user#{n}@example.com" }
+    first_name { Faker::Name.first_name }
+    last_name { Faker::Name.last_name }
+    is_admin { false }
+    email { Faker::Internet.safe_email }
+  end
+
+  factory :admin, parent: :user do
+    is_admin { true }
   end
 end

--- a/spec/factories/users_companies_relationships.rb
+++ b/spec/factories/users_companies_relationships.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :users_companies_relationship do
     user { create(:user) }
     company { create(:company) }
-    role { rand(0..2) }
+    role { rand(1..2) }
   end
 
   factory :company_owner, parent: :users_companies_relationship do

--- a/spec/factories/users_companies_relationships.rb
+++ b/spec/factories/users_companies_relationships.rb
@@ -2,7 +2,7 @@ FactoryBot.define do
   factory :users_companies_relationship do
     user { create(:user) }
     company { create(:company) }
-    role { srand(3) }
+    role { rand(0..2) }
   end
 
   factory :company_owner, parent: :users_companies_relationship do

--- a/spec/factories/users_companies_relationships.rb
+++ b/spec/factories/users_companies_relationships.rb
@@ -1,0 +1,19 @@
+FactoryBot.define do
+  factory :users_companies_relationship do
+    user { create(:user) }
+    company { create(:company) }
+    role { srand(3) }
+  end
+
+  factory :company_owner, parent: :users_companies_relationship do
+    role { 0 }
+  end
+
+  factory :employee, parent: :users_companies_relationship do
+    role { 1 }
+  end
+
+  factory :staff_member, parent: :users_companies_relationship do
+    role { 2 }
+  end
+end

--- a/spec/features/user_looks_information_about_company_other_user_spec.rb
+++ b/spec/features/user_looks_information_about_company_other_user_spec.rb
@@ -1,0 +1,26 @@
+require 'rails_helper'
+
+feature 'User looks Information About Company Other User' do
+  let(:users_companies_relationship) { create(:users_companies_relationship) }
+
+  scenario 'successfully' do
+    visit user_path(users_companies_relationship.user)
+
+    expect(page).to have_selector('div.company-role')
+    click_on users_companies_relationship.company.name
+
+    expect(page).to have_selector('h2',
+                                  text: users_companies_relationship.company.name)
+    expect(page).to have_selector('a', text: 'Company members')
+    click_on 'Company members'
+
+    expect(page).to have_selector('h3', text: 'Members:')
+
+    full_user_name = users_companies_relationship.user.first_name +
+                     ' ' + users_companies_relationship.user.last_name
+    expect(page).to have_selector('td',
+                                  text: full_user_name)
+    expect(page).to have_selector('td',
+                                  text: users_companies_relationship.role.capitalize)
+  end
+end

--- a/spec/features/user_looks_information_about_company_other_user_spec.rb
+++ b/spec/features/user_looks_information_about_company_other_user_spec.rb
@@ -21,6 +21,8 @@ feature 'User looks Information About Company Other User' do
     expect(page).to have_selector('td',
                                   text: full_user_name)
     expect(page).to have_selector('td',
-                                  text: users_companies_relationship.role.capitalize)
+                                  text: users_companies_relationship.role
+                                                                    .capitalize
+                                                                    .gsub('_', ' '))
   end
 end

--- a/spec/models/company_spec.rb
+++ b/spec/models/company_spec.rb
@@ -2,6 +2,12 @@ require 'rails_helper'
 
 describe Company, type: :model do
   let(:company) { create(:company) }
+
+  describe 'Associations' do
+    it { is_expected.to have_many(:users_companies_relationships).dependent(:destroy) }
+    it { is_expected.to have_many(:users).through(:users_companies_relationships) }
+  end
+
   describe 'Validations' do
     it 'is valid with valid attributes' do
       expect(company).to be_valid

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -3,6 +3,11 @@ require 'rails_helper'
 RSpec.describe User, type: :model do
   let(:user) { create(:user) }
 
+  describe 'Associations' do
+    it { is_expected.to have_one(:users_companies_relationship).dependent(:destroy) }
+    it { is_expected.to have_one(:company).through(:users_companies_relationship) }
+  end
+
   describe 'Validations' do
     it 'is valid with valid attributes' do
       expect(user).to be_valid

--- a/spec/models/user_spec.rb
+++ b/spec/models/user_spec.rb
@@ -19,4 +19,17 @@ RSpec.describe User, type: :model do
 
     it { should validate_presence_of(:email) }
   end
+
+  describe 'Method role' do
+    let(:users_companies_relationship) { create(:users_companies_relationship) }
+
+    it 'Return user role string' do
+      expect(users_companies_relationship.user.role)
+        .to eq(users_companies_relationship.role)
+    end
+
+    it 'User has no role' do
+      expect(user.role).to eq(nil)
+    end
+  end
 end

--- a/spec/models/users_companies_relationship_spec.rb
+++ b/spec/models/users_companies_relationship_spec.rb
@@ -1,0 +1,42 @@
+require 'rails_helper'
+
+RSpec.describe UsersCompaniesRelationship, type: :model do
+  describe 'associations' do
+    it { is_expected.to belong_to(:user) }
+    it { is_expected.to belong_to(:company) }
+  end
+
+  describe 'validations' do
+    context 'presence validation' do
+      it { is_expected.to validate_presence_of(:user) }
+      it { is_expected.to validate_presence_of(:company) }
+      it { is_expected.to validate_presence_of(:role) }
+    end
+  end
+
+  describe 'roles test\'s' do
+    let(:company_owner) { create(:company_owner) }
+    let(:employee) { create(:employee) }
+    let(:staff_member) { create(:staff_member) }
+
+    it do
+      is_expected.to define_enum_for(:role)
+        .with_values(company_owner: 0, employee: 1, staff_member: 2)
+    end
+
+    it 'he is company_owner' do
+      expect(company_owner.company_owner?).to be true
+      expect(company_owner.employee?).not_to be true
+    end
+
+    it 'he is employee' do
+      expect(employee.employee?).to be true
+      expect(company_owner.staff_member?).not_to be true
+    end
+
+    it 'he is staff_member' do
+      expect(staff_member.staff_member?).to be true
+      expect(staff_member.company_owner?).not_to be true
+    end
+  end
+end


### PR DESCRIPTION
# [Зв’язок користувачів з компаніями](https://github.com/IF-107-Ruby/paw-patrol/issues/46)

## Changes description

- Changed is_admin column type to boolean

- Add UsersCompaniesRelationship model

- Add Members controller for companie users

- Add methods full_user_name and user_company_content in UsersHelper

## Screnshots of the added pages

- Show information about user role and company link on User show page

![Знімок екрану з 2020-04-16 19-34-59](https://user-images.githubusercontent.com/48407015/79482450-8741de00-8019-11ea-88c2-c9cb9dd1263a.png)


- Add link to Company members on Company show page

![Знімок екрану з 2020-04-16 19-12-59](https://user-images.githubusercontent.com/48407015/79480100-5613de80-8016-11ea-974f-4702e3088e81.png)

- Add simple index page for Company members

![Знімок екрану з 2020-04-16 19-36-43](https://user-images.githubusercontent.com/48407015/79482558-ac365100-8019-11ea-8f79-d431ebcc9f59.png)

## Check list:
- [x] Integration Tests
- [x] Functional
- [x] Unit
- [x] Factories
- [x] Updated seed file