### PR TITLE
Feature/owner create units

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -4,6 +4,10 @@ class ApplicationController < ActionController::Base
 
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
 
+  def current_user
+    super || Guest.new
+  end
+
   private
 
   def pagy_decorated(*args)

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -1,7 +1,7 @@
 class UnitsController < ApplicationController
+  before_action :authenticate_user!, except: %i[index show]
   before_action :read_company_by_id
   before_action :read_unit_by_id, only: %i[show edit update destroy]
-  before_action :check_permission, except: %i[index show]
 
   def index
     @pagy, @units = pagy(@company.units, items: 10)
@@ -10,7 +10,7 @@ class UnitsController < ApplicationController
   def show; end
 
   def new
-    @unit = @company.units.build(parent_id: params[:parent_id])
+    @unit = authorize(@company.units.build(parent_id: params[:parent_id]))
   end
 
   def create
@@ -49,17 +49,10 @@ class UnitsController < ApplicationController
   end
 
   def read_unit_by_id
-    @unit = @company.units.find(params[:id])
+    @unit = authorize(@company.units.find(params[:id]))
   end
 
   def read_company_by_id
     @company = Company.find(params[:company_id])
-  end
-
-  def check_permission
-    unless current_user&.company_owner?(@company)
-      flash[:danger] = "Sorry, you don't have permission."
-      redirect_to(request.referer)
-    end
   end
 end

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -1,6 +1,7 @@
 class UnitsController < ApplicationController
   before_action :read_company_by_id
   before_action :read_unit_by_id, only: %i[show edit update destroy]
+  before_action :check_permission, except: %i[index show]
 
   def index
     @pagy, @units = pagy(@company.units, items: 10)
@@ -53,5 +54,12 @@ class UnitsController < ApplicationController
 
   def read_company_by_id
     @company = Company.find(params[:company_id])
+  end
+
+  def check_permission
+    unless current_user&.company_owner?(@company)
+      flash[:danger] = "Sorry, you don't have permission."
+      redirect_to(request.referer)
+    end
   end
 end

--- a/app/models/guest.rb
+++ b/app/models/guest.rb
@@ -1,0 +1,5 @@
+class Guest
+  def company_owner?(_)
+    false
+  end
+end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -17,4 +17,8 @@ class User < ApplicationRecord
   def role
     users_companies_relationship.role if company.present?
   end
+
+  def company_owner?(selected_company)
+    company == selected_company && role == 'company_owner'
+  end
 end

--- a/app/models/user.rb
+++ b/app/models/user.rb
@@ -18,7 +18,7 @@ class User < ApplicationRecord
     users_companies_relationship.role if company.present?
   end
 
-  def company_owner?(selected_company)
-    company == selected_company && role == 'company_owner'
+  def company_owner?(current_company)
+    role == 'company_owner' && company == current_company
   end
 end

--- a/app/policies/unit_policy.rb
+++ b/app/policies/unit_policy.rb
@@ -8,20 +8,20 @@ class UnitPolicy < ApplicationPolicy
   end
 
   def create?
-    check_company_owner?
+    company_owner?
   end
 
   def update?
-    check_company_owner?
+    company_owner?
   end
 
   def destroy?
-    check_company_owner?
+    company_owner?
   end
 
   private
 
-  def check_company_owner?
+  def company_owner?
     user.company_owner?(record.company)
   end
 

--- a/app/policies/unit_policy.rb
+++ b/app/policies/unit_policy.rb
@@ -1,0 +1,33 @@
+class UnitPolicy < ApplicationPolicy
+  def index?
+    true
+  end
+
+  def show?
+    true
+  end
+
+  def create?
+    check_company_owner?
+  end
+
+  def update?
+    check_company_owner?
+  end
+
+  def destroy?
+    check_company_owner?
+  end
+
+  private
+
+  def check_company_owner?
+    user.company_owner?(record.company)
+  end
+
+  class Scope < Scope
+    def resolve
+      scope.all
+    end
+  end
+end

--- a/app/views/layouts/_nav.html.slim
+++ b/app/views/layouts/_nav.html.slim
@@ -21,7 +21,7 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-light.shadow.fixed-top
           a.nav-link[href="/contact"]
             | Contact
 
-        - if current_user
+        - unless current_user.is_a?(Guest)
           - if current_user.is_admin?
             li.nav-item.dropdown
               a#navbarDropdownMenuLink.nav-link.dropdown-toggle aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" href="#"

--- a/app/views/units/_unit.html.slim
+++ b/app/views/units/_unit.html.slim
@@ -1,7 +1,8 @@
 .unit-link
   .unit-name
     = link_to unit.name, company_unit_path(@company, unit)
-  .unit-icons
-    div = link_to icon('fas', 'plus', class: 'strong'), new_company_unit_path(parent_id: unit)
-    div = link_to icon('fas', 'edit', class: 'strong'), [:edit, @company, unit], class: 'edit-link'
-    div = link_to icon('fas', 'trash-alt', class: 'strong'), company_unit_path(@company, unit), method: :delete, data: {confirm: "You sure?"}, class: 'delete-link'
+  - if current_user&.company_owner?(@company)
+    .unit-icons
+      div = link_to icon('fas', 'plus', class: 'strong'), new_company_unit_path(parent_id: unit)
+      div = link_to icon('fas', 'edit', class: 'strong'), [:edit, @company, unit], class: 'edit-link'
+      div = link_to icon('fas', 'trash-alt', class: 'strong'), company_unit_path(@company, unit), method: :delete, data: {confirm: "You sure?"}, class: 'delete-link'

--- a/app/views/units/_unit.html.slim
+++ b/app/views/units/_unit.html.slim
@@ -1,7 +1,7 @@
 .unit-link
   .unit-name
     = link_to unit.name, company_unit_path(@company, unit)
-  - if current_user&.company_owner?(@company)
+  - if current_user.company_owner?(@company)
     .unit-icons
       div = link_to icon('fas', 'plus', class: 'strong'), new_company_unit_path(parent_id: unit)
       div = link_to icon('fas', 'edit', class: 'strong'), [:edit, @company, unit], class: 'edit-link'

--- a/app/views/units/index.html.slim
+++ b/app/views/units/index.html.slim
@@ -2,7 +2,7 @@
   .row class='justify-content-between'
     .col
       h4 Units list
-    - if current_user&.company_owner?(@company)
+    - if current_user.company_owner?(@company)
       .col class='edit-delete-links justify-content-end'
         div = link_to icon('fas', 'plus', class: 'strong'), new_company_unit_path(parent_id: @unit)
 

--- a/app/views/units/index.html.slim
+++ b/app/views/units/index.html.slim
@@ -2,8 +2,9 @@
   .row class='justify-content-between'
     .col
       h4 Units list
-    .col class='edit-delete-links justify-content-end'
-      div = link_to icon('fas', 'plus', class: 'strong'), new_company_unit_path(parent_id: @unit)
+    - if current_user&.company_owner?(@company)
+      .col class='edit-delete-links justify-content-end'
+        div = link_to icon('fas', 'plus', class: 'strong'), new_company_unit_path(parent_id: @unit)
 
 = render 'unit_tree_structure', units: @units.arrange
 = pagy_bootstrap_nav(@pagy).html_safe

--- a/app/views/units/show.html.slim
+++ b/app/views/units/show.html.slim
@@ -11,7 +11,7 @@
   .row class='justify-content-between'
     .col
       h2 = @unit.name
-    - if current_user&.company_owner?(@company)
+    - if current_user.company_owner?(@company)
       .col class='edit-delete-links justify-content-end'
         div = link_to icon('fas', 'edit', class: 'strong'), [:edit, @company, @unit], class: 'edit-link'
         div = link_to icon('fas', 'trash-alt', class: 'strong'), company_unit_path(@company, @unit), method: :delete, data: {confirm: "You sure?"}, class: 'delete-link'

--- a/app/views/units/show.html.slim
+++ b/app/views/units/show.html.slim
@@ -11,8 +11,9 @@
   .row class='justify-content-between'
     .col
       h2 = @unit.name
-    .col class='edit-delete-links justify-content-end'
-      div = link_to icon('fas', 'edit', class: 'strong'), [:edit, @company, @unit], class: 'edit-link'
-      div = link_to icon('fas', 'trash-alt', class: 'strong'), company_unit_path(@company, @unit), method: :delete, data: {confirm: "You sure?"}, class: 'delete-link'
+    - if current_user&.company_owner?(@company)
+      .col class='edit-delete-links justify-content-end'
+        div = link_to icon('fas', 'edit', class: 'strong'), [:edit, @company, @unit], class: 'edit-link'
+        div = link_to icon('fas', 'trash-alt', class: 'strong'), company_unit_path(@company, @unit), method: :delete, data: {confirm: "You sure?"}, class: 'delete-link'
 
 = render 'unit_tree_structure', units: @unit.children.arrange

--- a/db/schema.rb
+++ b/db/schema.rb
@@ -55,9 +55,8 @@ ActiveRecord::Schema.define(version: 20_200_423_170_838) do
     t.datetime 'reset_password_sent_at'
     t.datetime 'remember_created_at'
     t.index ['email'], name: 'index_users_on_email', unique: true
-    t.index ['reset_password_token'],
-            name: 'index_users_on_reset_password_token',
-            unique: true
+    t.index ['reset_password_token'], name: 'index_users_on_reset_password_token',
+                                      unique: true
   end
 
   create_table 'users_companies_relationships', force: :cascade do |t|

--- a/spec/controllers/units_controller_spec.rb
+++ b/spec/controllers/units_controller_spec.rb
@@ -1,7 +1,10 @@
 require 'rails_helper'
 
 RSpec.describe UnitsController, type: :controller do
-  let!(:unit) { create(:unit) }
+  let!(:owner) { create(:user) }
+  let!(:company) { create(:company) }
+  let!(:company_owner) { create(:company_owner, company: company, user: owner) }
+  let!(:unit) { create(:unit, company: company) }
   let!(:valid_params) { FactoryBot.attributes_for :unit }
   let!(:invalid_params) { { name: '' } }
 
@@ -23,106 +26,148 @@ RSpec.describe UnitsController, type: :controller do
     end
   end
 
-  describe 'GET#new' do
-    it 'returns http success and assigns unit' do
-      get :new, params: { company_id: unit.company.id }
-      expect(response).to have_http_status(:success)
-      expect(assigns(:unit)).to be_a_new(Unit)
-    end
-  end
+  describe 'Units controller new, create, edit, update, destroy actions' do
+    context 'if user is company owner' do
+      before { sign_in owner }
 
-  describe 'POST#create' do
-    context 'with valid params' do
-      it 'creates a new unit' do
-        expect do
-          post :create, params: { unit: valid_params,
-                                  company_id: unit.company.id }
-        end.to change(Unit, :count).by(1)
-      end
-
-      it 'redirects to a new unit' do
-        post :create, params: { unit: valid_params,
-                                company_id: unit.company.id }
-        expect(response).to have_http_status(:redirect)
-        expect(response).to redirect_to(company_unit_path(Unit.last.company,
-                                                          Unit.last))
-        expect(flash[:success]).to be_present
-      end
-    end
-    context 'with invalid params' do
-      it 'do not create new unit' do
-        expect do
-          post :create, params: { unit: invalid_params,
-                                  company_id: unit.company.id }
-        end.not_to change(Unit, :count)
-      end
-      it 'render new page with flash' do
-        post :create, params: { unit: invalid_params,
-                                company_id: unit.company.id }
-        expect(response).to have_http_status(:success)
-        expect(flash[:danger]).to be_present
-      end
-    end
-  end
-
-  describe 'GET#edit' do
-    before do
-      get :edit, params: { id: unit.id, company_id: unit.company.id }
-    end
-    it 'returns http success and assign unit' do
-      expect(response).to have_http_status(:success)
-      expect(assigns(:unit)).to eq(unit)
-    end
-  end
-
-  describe 'PUT#update' do
-    context 'with valid params' do
-      before do
-        put :update, params: { id: unit.id,
-                               unit: valid_params.merge!(name: 'New name'),
-                               company_id: unit.company.id }
-      end
-
-      it 'assign the unit' do
-        expect(assigns(:unit)).to eq(unit)
-        expect(response).to have_http_status(:redirect)
-        expect(response).to redirect_to(company_unit_path(unit.company, unit))
-        expect(flash[:success]).to be_present
-      end
-
-      it 'updates unit name' do
-        unit.reload
-        expect(unit.name).to eq(valid_params[:name])
-      end
-    end
-    context 'with invalid params' do
-      it 'do not update unit' do
-        expect do
-          put :update, params: { id: unit.id, unit: invalid_params,
-                                 company_id: unit.company.id }
+      describe 'GET#new' do
+        it 'returns http success and assigns unit' do
+          get :new, params: { company_id: unit.company.id }
+          expect(response).to have_http_status(:success)
+          expect(assigns(:unit)).to be_a_new(Unit)
         end
-          .not_to change { unit.reload.name }
       end
-      it 'render edit page with flash' do
-        put :update, params: { id: unit.id, unit: invalid_params,
-                               company_id: unit.company.id }
-        expect(response).to have_http_status(:success)
-        expect(flash[:danger]).to be_present
-      end
-    end
-  end
 
-  describe 'DELETE#destroy' do
-    it 'should delete unit' do
-      expect do
-        delete :destroy, params: { id: unit.id, company_id: unit.company.id }
-      end.to change(Unit, :count).by(-1)
+      describe 'POST#create' do
+        context 'with valid params' do
+          it 'creates a new unit' do
+            expect do
+              post :create, params: { unit: valid_params,
+                                      company_id: unit.company.id }
+            end.to change(Unit, :count).by(1)
+          end
+
+          it 'redirects to a new unit' do
+            post :create, params: { unit: valid_params,
+                                    company_id: unit.company.id }
+            expect(response).to have_http_status(:redirect)
+            expect(response).to redirect_to(company_unit_path(Unit.last.company,
+                                                              Unit.last))
+            expect(flash[:success]).to be_present
+          end
+        end
+        context 'with invalid params' do
+          it 'do not create new unit' do
+            expect do
+              post :create, params: { unit: invalid_params,
+                                      company_id: unit.company.id }
+            end.not_to change(Unit, :count)
+          end
+          it 'render new page with flash' do
+            post :create, params: { unit: invalid_params,
+                                    company_id: unit.company.id }
+            expect(response).to have_http_status(:success)
+            expect(flash[:danger]).to be_present
+          end
+        end
+      end
+
+      describe 'GET#edit' do
+        before do
+          get :edit, params: { id: unit.id, company_id: unit.company.id }
+        end
+        it 'returns http success and assign unit' do
+          expect(response).to have_http_status(:success)
+          expect(assigns(:unit)).to eq(unit)
+        end
+      end
+
+      describe 'PUT#update' do
+        context 'with valid params' do
+          before do
+            put :update, params: { id: unit.id,
+                                   unit: valid_params.merge!(name: 'New name'),
+                                   company_id: unit.company.id }
+          end
+
+          it 'assign the unit' do
+            expect(assigns(:unit)).to eq(unit)
+            expect(response).to have_http_status(:redirect)
+            expect(response).to redirect_to(company_unit_path(unit.company, unit))
+            expect(flash[:success]).to be_present
+          end
+
+          it 'updates unit name' do
+            unit.reload
+            expect(unit.name).to eq(valid_params[:name])
+          end
+        end
+        context 'with invalid params' do
+          it 'do not update unit' do
+            expect do
+              put :update, params: { id: unit.id, unit: invalid_params,
+                                     company_id: unit.company.id }
+            end
+              .not_to change { unit.reload.name }
+          end
+          it 'render edit page with flash' do
+            put :update, params: { id: unit.id, unit: invalid_params,
+                                   company_id: unit.company.id }
+            expect(response).to have_http_status(:success)
+            expect(flash[:danger]).to be_present
+          end
+        end
+      end
+
+      describe 'DELETE#destroy' do
+        it 'should delete unit' do
+          expect do
+            delete :destroy, params: { id: unit.id, company_id: unit.company.id }
+          end.to change(Unit, :count).by(-1)
+        end
+        it 'should redirect to units' do
+          delete :destroy, params: { id: unit.id, company_id: unit.company.id }
+          expect(response).to have_http_status(:redirect)
+          expect(response).to redirect_to(company_units_path(unit.company))
+          expect(flash[:success]).to be_present
+        end
+      end
     end
-    it 'should redirect to units' do
-      delete :destroy, params: { id: unit.id, company_id: unit.company.id }
-      expect(response).to have_http_status(:redirect)
-      expect(response).to redirect_to(company_units_path(unit.company))
-      expect(flash[:success]).to be_present
+
+    context 'if user is not company owner' do
+      describe 'GET#new' do
+        it 'returns redirect' do
+          get :new, params: { company_id: unit.company.id }
+          expect(response).to have_http_status(:redirect)
+        end
+      end
+
+      describe 'POST#create' do
+        it 'does not create a new unit' do
+          expect do
+            post :create, params: { unit: valid_params,
+                                    company_id: unit.company.id }
+          end.not_to change(Unit, :count)
+          expect(flash[:success]).not_to be_present
+        end
+      end
+
+      describe 'GET#edit' do
+        before do
+          get :edit, params: { id: unit.id, company_id: unit.company.id }
+        end
+        it 'returns redirect' do
+          expect(response).to have_http_status(:redirect)
+        end
+      end
+
+      describe 'DELETE#destroy' do
+        it 'does not delete user' do
+          expect do
+            delete :destroy, params: { id: unit.id, company_id: unit.company.id }
+          end.not_to change(Unit, :count)
+        end
+      end
     end
   end
 end

--- a/spec/controllers/units_controller_spec.rb
+++ b/spec/controllers/units_controller_spec.rb
@@ -1,8 +1,8 @@
 require 'rails_helper'
 
 RSpec.describe UnitsController, type: :controller do
-  let!(:owner) { create(:user) }
   let!(:company) { create(:company) }
+  let!(:owner) { create(:user) }
   let!(:company_owner) { create(:company_owner, company: company, user: owner) }
   let!(:unit) { create(:unit, company: company) }
   let!(:valid_params) { FactoryBot.attributes_for :unit }

--- a/spec/features/unit_crud_spec.rb
+++ b/spec/features/unit_crud_spec.rb
@@ -1,7 +1,12 @@
 require 'rails_helper'
 
 feature 'unit crud' do
-  let!(:unit) { create(:unit) }
+  let!(:owner) { create(:user) }
+  let!(:company) { create(:company) }
+  let!(:company_owner) { create(:company_owner, company: company, user: owner) }
+  let!(:unit) { create(:unit, company: company) }
+
+  before { login_as owner }
 
   scenario 'successful creating unit' do
     visit new_company_unit_path(unit.company)


### PR DESCRIPTION
# [Тільки адмін компанії може створювати кімнати ](hhttps://github.com/IF-107-Ruby/paw-patrol/projects/1#card-36068674)

Add company owner permissions:

- all users can see unit index and show pages

- only company owner has ability to create, edit and delete units

- users beside company owner can't see unit create, edit and delete buttons

![Screen Shot 2020-04-24 at 9 19 02 PM](https://user-images.githubusercontent.com/55596322/80249038-cacfc400-8679-11ea-9387-da363f6d9ada.png)

![Screen Shot 2020-04-24 at 9 16 16 PM](https://user-images.githubusercontent.com/55596322/80249050-cd321e00-8679-11ea-9ea9-ed1b9ee3d4cc.png)
 

## Changes description

## Screnshots of the added pages

## Check list:
- [x] Integration Tests
- [ ] Functional
- [x] Unit
- [ ] Factories
- [ ] Updated seed file
