### PR TITLE
Fix/company-owner-permission

### DIFF
--- a/app/controllers/application_controller.rb
+++ b/app/controllers/application_controller.rb
@@ -5,10 +5,6 @@ class ApplicationController < ActionController::Base
   rescue_from Pundit::NotAuthorizedError, with: :user_not_authorized
   rescue_from ActiveRecord::RecordNotFound, with: :record_not_found
 
-  def current_user
-    super || Guest.new
-  end
-
   private
 
   def pagy_decorated(*args)

--- a/app/controllers/units_controller.rb
+++ b/app/controllers/units_controller.rb
@@ -1,10 +1,10 @@
 class UnitsController < ApplicationController
-  before_action :authenticate_user!, except: %i[index show]
+  before_action :authenticate_user!
   before_action :read_company_by_id
   before_action :read_unit_by_id, only: %i[show edit update destroy]
 
   def index
-    @pagy, @units = pagy(@company.units, items: 10)
+    @units = @company.units
   end
 
   def show; end

--- a/app/models/guest.rb
+++ b/app/models/guest.rb
@@ -1,5 +1,0 @@
-class Guest
-  def company_owner?(_)
-    false
-  end
-end

--- a/app/views/layouts/_nav.html.slim
+++ b/app/views/layouts/_nav.html.slim
@@ -21,7 +21,7 @@ nav.navbar.navbar-expand-lg.navbar-light.bg-light.shadow.fixed-top
           a.nav-link[href="/contact"]
             | Contact
 
-        - unless current_user.is_a?(Guest)
+        - if current_user
           - if current_user.is_admin?
             li.nav-item.dropdown
               a#navbarDropdownMenuLink.nav-link.dropdown-toggle aria-expanded="false" aria-haspopup="true" data-toggle="dropdown" href="#"

--- a/app/views/units/index.html.slim
+++ b/app/views/units/index.html.slim
@@ -7,4 +7,3 @@
         div = link_to icon('fas', 'plus', class: 'strong'), new_company_unit_path(parent_id: @unit)
 
 = render 'unit_tree_structure', units: @units.arrange
-= pagy_bootstrap_nav(@pagy).html_safe

--- a/spec/controllers/units_controller_spec.rb
+++ b/spec/controllers/units_controller_spec.rb
@@ -3,6 +3,7 @@ require 'rails_helper'
 RSpec.describe UnitsController, type: :controller do
   let!(:company) { create(:company) }
   let!(:owner) { create(:user) }
+  let!(:user) { create(:user) }
   let!(:company_owner) { create(:company_owner, company: company, user: owner) }
   let!(:unit) { create(:unit, company: company) }
   let!(:valid_params) { FactoryBot.attributes_for :unit }
@@ -10,6 +11,7 @@ RSpec.describe UnitsController, type: :controller do
 
   describe 'GET#index' do
     it 'assigns units and renders template' do
+      sign_in user
       get :index, params: { company_id: unit.company.id }
       expect(assigns(:units)).to eq([unit])
       expect(response).to render_template('index')
@@ -17,10 +19,9 @@ RSpec.describe UnitsController, type: :controller do
   end
 
   describe 'GET#show' do
-    before do
-      get :show, params: { id: unit.id, company_id: unit.company.id }
-    end
     it 'returns http success and assigns unit' do
+      sign_in user
+      get :show, params: { id: unit.id, company_id: unit.company.id }
       expect(response).to have_http_status(:success)
       expect(assigns(:unit)).to eq(unit)
     end


### PR DESCRIPTION
# [Fix/company-owner-permission](https://issueurl)

Delete Guest class, remove units pagination

- Only signed in user has access to unit actions
- Only company owner can create, edit, delete units
- Signed in user has ability to see unit index and show pages, but doesn't have ability to create, edit, delete (later it will be realized as company member)


## Check list:
- [ ] Integration Tests
- [ ] Functional
- [ ] Unit
- [ ] Factories
- [ ] Updated seed file
