### PR TITLE
Feature/ticket unit id auto filing

### DIFF
--- a/app/controllers/company/tickets_controller.rb
+++ b/app/controllers/company/tickets_controller.rb
@@ -7,8 +7,7 @@ class Company
     end
 
     def new
-      # TODO: Implement unit id auto filling
-      @ticket = Ticket.new
+      @ticket = Ticket.new(unit_id: params[:unit_id])
       authorize([:company, @ticket])
     end
 

--- a/app/views/company/tickets/_form.html.slim
+++ b/app/views/company/tickets/_form.html.slim
@@ -26,7 +26,8 @@
                           'tabindex' => '-98',
                           'title' => 'Select unit',
                           'data-live-search' => true,
-                          required: 'required' }
+                          required: 'required',
+                          prompt: true }
               .col-12
                 .submit-field
                   h5.pb-2 Describe your problem

--- a/spec/features/company/employee_post_a_ticket_spec.rb
+++ b/spec/features/company/employee_post_a_ticket_spec.rb
@@ -34,6 +34,7 @@ feature 'EmployeePostATicket' do
 
     expect(page).to have_selector('.dashboard-headline h3', text: 'Post a Ticket')
     expect(page).to have_selector('.ticket-form')
+
     fill_in 'ticket_name', with: ticket_attributes[:name]
     fill_in_trix_editor('ticket_description_trix_input_ticket',
                         ticket_attributes[:description])

--- a/spec/features/company/employee_post_a_ticket_spec.rb
+++ b/spec/features/company/employee_post_a_ticket_spec.rb
@@ -29,6 +29,22 @@ feature 'EmployeePostATicket' do
                                   text: 'Ticket posted!')
   end
 
+  scenario 'successfully for unit id auto filling' do
+    visit new_company_ticket_path(unit_id: unit.id)
+
+    expect(page).to have_selector('.dashboard-headline h3', text: 'Post a Ticket')
+    expect(page).to have_selector('.ticket-form')
+    fill_in 'ticket_name', with: ticket_attributes[:name]
+    fill_in_trix_editor('ticket_description_trix_input_ticket',
+                        ticket_attributes[:description])
+    within('.dashboard-content-inner') do
+      click_on 'Post a Ticket'
+    end
+
+    expect(page).to have_selector('.notification.success.closeable',
+                                  text: 'Ticket posted!')
+  end
+
   scenario 'unsuccessfully' do
     expect(page).to have_selector('.ticket-form')
 


### PR DESCRIPTION
# [Implement unit id auto filling at Ticket create](https://issueurl)

## Changes description

- Implemented unit id auto filling at Ticket create.

## Screnshots of the added pages

- If unit id exist:

![Знімок екрану з 2020-05-14 13-11-43](https://user-images.githubusercontent.com/48407015/81922488-dbbe8600-95e4-11ea-933e-a96ace6e1682.png)

- if unit id not exist:

![Знімок екрану з 2020-05-14 13-12-16](https://user-images.githubusercontent.com/48407015/81922550-f55fcd80-95e4-11ea-8e70-d8835ea35a99.png)

## Check list:
- [x] Integration Tests
- [ ] Functional
- [ ] Unit
- [ ] Factories
- [ ] Updated seed file
