### PR TITLE
Add render_views by default for all controller specs

### DIFF
--- a/spec/controllers/admin/dashboards_controller_spec.rb
+++ b/spec/controllers/admin/dashboards_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Admin::DashboardsController, type: :controller do
-  render_views
-
   let(:admin) { create(:admin) }
 
   describe 'GET#index' do

--- a/spec/controllers/admin/feedbacks_controller_spec.rb
+++ b/spec/controllers/admin/feedbacks_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Admin::FeedbacksController, type: :controller do
-  render_views
-
   let(:admin) { create(:admin) }
   let(:feedback) { create(:feedback) }
 

--- a/spec/controllers/admin/users_controller_spec.rb
+++ b/spec/controllers/admin/users_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Admin::UsersController, type: :controller do
-  render_views
-
   let!(:admin) { create(:admin) }
   let!(:user) { create(:user) }
   let!(:valid_params) { FactoryBot.attributes_for :user }

--- a/spec/controllers/api/v1/tickets_controller_spec.rb
+++ b/spec/controllers/api/v1/tickets_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Api::V1::TicketsController, type: :controller do
-  render_views
-
   include_context 'employee with ticket'
 
   describe 'GET#index' do

--- a/spec/controllers/companies_controller_spec.rb
+++ b/spec/controllers/companies_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe CompaniesController, type: :controller do
-  render_views
-
   let(:company_registrations_form_valid_params) do
     attributes_for(:company_registrations_form_params)
   end

--- a/spec/controllers/company/dashboards_controller_spec.rb
+++ b/spec/controllers/company/dashboards_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Company::DashboardsController, type: :controller do
-  render_views
-
   let!(:company) { create(:company) }
   let!(:employee) { create(:employee, company: company) }
   let!(:company_owner) { create(:company_owner, company: company) }

--- a/spec/controllers/company/profiles_controller_spec.rb
+++ b/spec/controllers/company/profiles_controller_spec.rb
@@ -17,10 +17,16 @@ RSpec.describe Company::ProfilesController, type: :controller do
   end
 
   describe 'Get#Edit' do
-    subject { get :edit }
+    before { get :edit }
 
-    it { is_expected.to have_http_status(:success) }
-    it { is_expected.to render_template('edit') }
+    it 'return current user' do
+      expect(assigns(:user)).to eq(employee)
+    end
+
+    it 'render edit template' do
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template('edit')
+    end
   end
 
   describe 'Patch#Update' do

--- a/spec/controllers/company/profiles_controller_spec.rb
+++ b/spec/controllers/company/profiles_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Company::ProfilesController, type: :controller do
-  render_views
-
   let(:user_password) { '123456' }
   let!(:company) { create(:company) }
   let!(:employee) do

--- a/spec/controllers/company/profiles_controller_spec.rb
+++ b/spec/controllers/company/profiles_controller_spec.rb
@@ -19,7 +19,7 @@ RSpec.describe Company::ProfilesController, type: :controller do
   describe 'Get#Edit' do
     before { get :edit }
 
-    it 'return current user' do
+    it 'return user object' do
       expect(assigns(:user)).to eq(employee)
     end
 

--- a/spec/controllers/company/reviews_controller_spec.rb
+++ b/spec/controllers/company/reviews_controller_spec.rb
@@ -13,24 +13,38 @@ RSpec.describe Company::ReviewsController, type: :controller do
   end
 
   describe 'GET #show' do
-    before { sign_in employee }
-
     let!(:review) { create(:review, ticket: ticket) }
 
-    subject { get :show, params: { ticket_id: ticket.id } }
+    before do
+      sign_in employee
+      get :show, params: { ticket_id: ticket.id }
+    end
 
-    it { is_expected.to have_http_status(:success) }
-    it { is_expected.to render_template('show') }
+    it 'return review object' do
+      expect(assigns(:review)).to eq(review)
+    end
+
+    it 'render show template' do
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template('show')
+    end
   end
 
   describe 'GET #new' do
     context 'Employee create review' do
-      before { sign_in employee }
+      before do
+        sign_in employee
+        get :new, params: { ticket_id: ticket.id }
+      end
 
-      subject { get :new, params: { ticket_id: ticket.id } }
+      it 'initiates empty review object' do
+        expect(assigns(:review)).to be_a_new(Review)
+      end
 
-      it { is_expected.to have_http_status(:success) }
-      it { is_expected.to render_template('new') }
+      it 'render new template' do
+        expect(response).to have_http_status(:success)
+        expect(response).to render_template('new')
+      end
     end
 
     context 'Staff member create review' do

--- a/spec/controllers/company/reviews_controller_spec.rb
+++ b/spec/controllers/company/reviews_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Company::ReviewsController, type: :controller do
-  render_views
-
   include_context 'employee with ticket'
   let!(:staff_member) { create(:staff_member, company: company) }
   let(:review_params) { FactoryBot.attributes_for :review }

--- a/spec/controllers/company/room_employees_controller_spec.rb
+++ b/spec/controllers/company/room_employees_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Company::RoomEmployeesController, type: :controller do
-  render_views
-
   let!(:company) { create(:company) }
   let!(:company_owner) { create(:company_owner, company: company) }
   let!(:staff_member) { create(:staff_member, company: company) }

--- a/spec/controllers/company/tickets_controller_spec.rb
+++ b/spec/controllers/company/tickets_controller_spec.rb
@@ -11,12 +11,17 @@ describe Company::TicketsController, type: :controller do
   describe 'GET #show' do
     before do
       sign_in employee
+      get :show, params: { id: ticket.id }
     end
 
-    subject { get :show, params: { id: ticket.id } }
+    it 'return ticket object' do
+      expect(assigns(:ticket)).to eq(ticket)
+    end
 
-    it { is_expected.to have_http_status(:success) }
-    it { is_expected.to render_template('show') }
+    it 'render show template' do
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template('show')
+    end
   end
 
   describe 'Authentication and authorization tests' do

--- a/spec/controllers/company/tickets_controller_spec.rb
+++ b/spec/controllers/company/tickets_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 describe Company::TicketsController, type: :controller do
-  render_views
-
   include_context 'employee with ticket'
   let!(:user) { create(:staff_member, company: company) }
   let!(:ticket_valid_params) { FactoryBot.attributes_for :ticket }

--- a/spec/controllers/company/units_controller_spec.rb
+++ b/spec/controllers/company/units_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Company::UnitsController, type: :controller do
-  render_views
-
   let!(:company) { create(:company) }
   let!(:company_owner) { create(:company_owner, company: company) }
   let!(:unit) { create(:unit, company: company) }

--- a/spec/controllers/company/user_units_controller_spec.rb
+++ b/spec/controllers/company/user_units_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe Company::UserUnitsController, type: :controller do
-  render_views
-
   let!(:company) { create(:company) }
   let!(:unit) { create(:unit, :with_employee_and_ticket, company: company) }
   let!(:employee) { unit.users.first }

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -6,23 +6,51 @@ RSpec.describe FeedbacksController, type: :controller do
   let(:feedback_valid_params) { FactoryBot.attributes_for :feedback }
   let(:feedback_invalid_params) { { user_full_name: '', email: '', message: '' } }
 
+  describe 'Get #new' do
+    before do
+      get :new
+    end
+
+    it 'initiates empty feedback object' do
+      expect(assigns(:feedback)).to be_a_new(Feedback)
+    end
+
+    it 'render new template' do
+      expect(response).to have_http_status(:success)
+      expect(response).to render_template('new')
+    end
+  end
+
   describe 'POST #create' do
     context 'with valid params' do
-      before { post :create, params: { feedback: feedback_valid_params } }
+      it 'create a new feedback' do
+        expect do
+          post :create, params: { feedback: feedback_valid_params }
+        end.to change(Feedback, :count).by(1)
+      end
 
-      it { is_expected.to set_flash[:success] }
-      it { is_expected.not_to set_flash.now[set_flash.now[:warning]] }
+      it 'redirects to the root path' do
+        post :create, params: { feedback: feedback_valid_params }
 
-      it { is_expected.to redirect_to(root_path) }
+        is_expected.to set_flash[:success]
+        is_expected.to redirect_to(root_path)
+      end
     end
 
     context 'with invalid params' do
-      before { post :create, params: { feedback: feedback_invalid_params } }
+      it 'cannot create a new feedback' do
+        expect do
+          post :create, params: { feedback: feedback_invalid_params }
+        end.to change(Feedback, :count).by(0)
+      end
 
-      it { is_expected.to set_flash.now[:warning] }
-      it { is_expected.not_to set_flash[:success] }
+      it 'render new template' do
+        post :create, params: { feedback: feedback_invalid_params }
 
-      it { is_expected.to render_template('new') }
+        is_expected.to set_flash.now[:warning]
+        is_expected.not_to set_flash[:success]
+        is_expected.to render_template('new')
+      end
     end
   end
 end

--- a/spec/controllers/feedbacks_controller_spec.rb
+++ b/spec/controllers/feedbacks_controller_spec.rb
@@ -1,8 +1,6 @@
 require 'rails_helper'
 
 RSpec.describe FeedbacksController, type: :controller do
-  render_views
-
   let(:feedback_valid_params) { FactoryBot.attributes_for :feedback }
   let(:feedback_invalid_params) { { user_full_name: '', email: '', message: '' } }
 

--- a/spec/rails_helper.rb
+++ b/spec/rails_helper.rb
@@ -47,4 +47,6 @@ RSpec.configure do |config|
   config.filter_rails_from_backtrace!
   # arbitrary gems may also be filtered via:
   # config.filter_gems_from_backtrace("gem name")
+
+  config.render_views
 end

--- a/spec/support/render_views.rb
+++ b/spec/support/render_views.rb
@@ -1,0 +1,1 @@
+RSpec.configure(&:render_views)

--- a/spec/support/render_views.rb
+++ b/spec/support/render_views.rb
@@ -1,1 +1,0 @@
-RSpec.configure(&:render_views)


### PR DESCRIPTION
# [Add render_views by default for all controller specs](https://issueurl)

## Changes description

- Added render_views file to spec/support directory;

- Removed render_views calls from controller specs;

- Rewrote feedbacks_controller_spec file;

- Added new tests for Reviews and Tickets controllers;

## Screnshots of the added pages

## Check list:
- [ ] Integration Tests
- [x] Functional
- [x] Unit
- [ ] Factories
- [ ] Updated seed file
